### PR TITLE
add entry_points to setup.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ pip
 git clone https://github.com/haskellcamargo/sclack.git
 cd sclack
 pip3 install -r requirements.txt
-chmod +x ./app.py
-./app.py
+pip3 install .
+sclack
 ```
 pipenv
 ```bash
@@ -53,7 +53,7 @@ cd sclack
 export PIPENV_VENV_IN_PROJECT=1
 pipenv install # install deps
 pipenv shell # enter virtualenv
-python app.py # run app
+sclack # run app
 ```
 
 ### From Binary
@@ -62,7 +62,7 @@ If you don't have Python installed, you can get the compiled binary for Sclack
 on [releases](https://github.com/haskellcamargo/sclack/releases) page. Versions **will be** available for Linux x86/x64 and OS X.
 
 ## Running
-Run `./app.py` after giving the correct permissions. If you don't have a `~/.sclack` file, you can generate one here by providing your workspace token. You can change the theme, enable or disable images, emojis, markdown, configure keyboards and everything else on `config.json`. Important: use `q` to quit!
+Run `sclack`. If you don't have a `~/.sclack` file, you can generate one here by providing your workspace token. You can change the theme, enable or disable images, emojis, markdown, configure keyboards and everything else on `config.json`. Important: use `q` to quit!
 
 Your `~/.sclack` file will look like:
 

--- a/sclack/__main__.py
+++ b/sclack/__main__.py
@@ -580,10 +580,16 @@ def ask_for_token(json_config):
             config_file.write(json.dumps(token_config, indent=False))
             json_config.update(token_config)
 
-if __name__ == '__main__':
+
+def main():
     json_config = {}
     with open('./config.json', 'r') as config_file:
         json_config.update(json.load(config_file))
     ask_for_token(json_config)
     app = App(json_config)
     app.start()
+
+
+if __name__ == '__main__':
+    main()
+

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,9 @@ setup(
     author_email='marcelocamargo@linuxmail.org',
     url='https://github.com/haskellcamargo/sclack',
     packages=['sclack'],
+    entry_points={
+        'console_scripts': ['sclack=sclack.__main__:main'],
+    },
     install_requires=[
         'asyncio',
         'urwid>2',


### PR DESCRIPTION
with this change a console_script is generated to be able to launch
sclack by just calling out sclack.

Measures are in place to also be able to launch by calling
`python3 -m sclack`

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>