### PR TITLE
Replace rtm_send_message with api_call('chat.postMessage')

### DIFF
--- a/app.py
+++ b/app.py
@@ -532,7 +532,7 @@ class App:
         else:
             channel = self.store.state.channel['id']
             if message.strip() != '':
-                self.store.slack.rtm_send_message(channel, message)
+                self.store.post_message(channel, message)
                 self.leave_edit_mode()
 
     def unhandled_input(self, key):

--- a/sclack/store.py
+++ b/sclack/store.py
@@ -126,5 +126,14 @@ class Store:
             text=text
         )
 
+    def post_message(self, channel_id, message):
+        return self.slack.api_call(
+            'chat.postMessage',
+            channel=channel_id,
+            as_user=True,
+            link_names=True,
+            text=message
+        )
+
     def get_presence(self, user_id):
         return self.slack.api_call('users.getPresence', user=user_id)


### PR DESCRIPTION
Replace rtm_send_message with api_call('chat.postMessage') to parse message fully, support mention and channel highlight

Fix issue https://github.com/haskellcamargo/sclack/issues/41