### PR TITLE
Use the maximum limit of 1000 for listing channels

### DIFF
--- a/sclack/store.py
+++ b/sclack/store.py
@@ -81,6 +81,7 @@ class Store:
         conversations = self.slack.api_call(
             'users.conversations',
             exclude_archived=True,
+            limit=1000, # 1k is max limit
             types='public_channel,private_channel,im'
         )['channels']
         for channel in conversations:


### PR DESCRIPTION
This is a bit of a hacky fix for an issue I had where some of my DM threads were not showing up in the quick switcher.