### PR TITLE
Add usage of XDG data dir for tokens

### DIFF
--- a/app.py
+++ b/app.py
@@ -27,6 +27,12 @@ loop = asyncio.get_event_loop()
 
 SCLACK_SUBTYPE = 'sclack_message'
 
+def get_token_file():
+    base = os.path.expanduser(os.environ.get('XDG_DATA_HOME', '~'))
+    return os.path.join(base, 'sclack')
+
+TOKEN_FILE = get_token_file()
+
 
 class SclackEventLoop(urwid.AsyncioEventLoop):
     def run(self):
@@ -665,17 +671,17 @@ class App:
         sys.exit()
 
 def ask_for_token(json_config):
-    if os.path.isfile(os.path.expanduser('~/.sclack')):
-        with open(os.path.expanduser('~/.sclack'), 'r') as user_file:
+    if os.path.isfile(TOKEN_FILE):
+        with open(TOKEN_FILE, 'r') as user_file:
             # Compatible with legacy configuration file
             new_config = json.load(user_file)
             if not 'workspaces' in new_config:
                 new_config['workspaces'] = {'default': new_config['token']}
             json_config.update(new_config)
     else:
-        print('There is no ~/.sclack file. Let\'s create one!')
+        print('There is no %s file. Let\'s create one!' % TOKEN_FILE)
         token = input('What is your Slack workspace token? ')
-        with open(os.path.expanduser('~/.sclack'), 'w') as config_file:
+        with open(TOKEN_FILE, 'w') as config_file:
             token_config = {'workspaces': {'default': token}}
             config_file.write(json.dumps(token_config, indent=False))
             json_config.update(token_config)


### PR DESCRIPTION
I've added basic support for the XDG basedir spec here by storing the data file in the relevant location if XDG_DATA_HOME has been set.