### PR TITLE
Fix unread message for starred items

### DIFF
--- a/sclack/store.py
+++ b/sclack/store.py
@@ -20,10 +20,12 @@ class State:
         self.online_users = set()
         self.is_snoozed = False
 
+
 class Cache:
     def __init__(self):
         self.avatar = {}
         self.picture = {}
+
 
 class Store:
     def __init__(self, workspaces, config):
@@ -165,7 +167,7 @@ class Store:
         :return:
         """
         self.state.stars = list(filter(
-            lambda star: star.get('type', '') in ('channel', 'im', 'group', ),
+            lambda star: star.get('type', '') in ('channel', 'im', 'group',),
             self.slack.api_call('stars.list')['items']
         ))
 

--- a/sclack/utils/channel.py
+++ b/sclack/utils/channel.py
@@ -1,0 +1,48 @@
+def get_group_name(group_raw_name):
+    """
+    TODO Remove last number
+    :param group_raw_name:
+    :return:
+    """
+    if group_raw_name[:5] == 'mpdm-':
+        group_parts = group_raw_name[5:].split('--')
+        group_parts = ['@{}'.format(item) for item in group_parts]
+        return ', '.join(group_parts)
+
+    return group_raw_name
+
+
+def is_valid_channel_id(channel_id):
+    """
+    Check whether channel_id is valid
+    :param channel_id:
+    :return:
+    """
+    return channel_id[0] in ('C', 'G', 'D')
+
+
+def is_channel(channel_id):
+    """
+    Is a channel
+    :param channel_id:
+    :return:
+    """
+    return channel_id[0] == 'C'
+
+
+def is_dm(channel_id):
+    """
+    Is direct message
+    :param channel_id:
+    :return:
+    """
+    return channel_id[0] == 'D'
+
+
+def is_group(channel_id):
+    """
+    Is a group
+    :param channel_id:
+    :return:
+    """
+    return channel_id[0] == 'G'


### PR DESCRIPTION
After merged starred feature, the number of unread messages in starred list is not updated.
This PR to fix that problem
Beside that, there is an improvement on select_channel, avoid redundant loop.