### PR TITLE
Minor fixes to changes in Slack API

### DIFF
--- a/app.py
+++ b/app.py
@@ -367,10 +367,15 @@ class App:
                 is_dm_workaround_please_remove_me=True
             )
         else:
+            are_more_members = False
+            if self.store.state.members['response_metadata']:
+                if self.store.state.members['response_metadata']['next_cursor']:
+                    are_more_members = True
             header = ChannelHeader(
                 name=self.store.state.channel['name'],
                 topic=self.store.state.channel['topic']['value'],
                 num_members=len(self.store.state.members['members']),
+                more_members=are_more_members,
                 pin_count=self.store.state.pin_count,
                 is_private=self.store.state.channel.get('is_group', False),
                 is_starred=self.store.state.channel.get('is_starred', False)

--- a/app.py
+++ b/app.py
@@ -368,8 +368,8 @@ class App:
             )
         else:
             are_more_members = False
-            if self.store.state.members['response_metadata']:
-                if self.store.state.members['response_metadata']['next_cursor']:
+            if self.store.state.members.get('response_metadata', None):
+                if self.store.state.members['response_metadata'].get('next_cursor', None):
                     are_more_members = True
             header = ChannelHeader(
                 name=self.store.state.channel['name'],

--- a/app.py
+++ b/app.py
@@ -370,7 +370,7 @@ class App:
             header = ChannelHeader(
                 name=self.store.state.channel['name'],
                 topic=self.store.state.channel['topic']['value'],
-                num_members=len(self.store.state.channel['members']),
+                num_members=len(self.store.state.members['members']),
                 pin_count=self.store.state.pin_count,
                 is_private=self.store.state.channel.get('is_group', False),
                 is_starred=self.store.state.channel.get('is_starred', False)

--- a/sclack/components.py
+++ b/sclack/components.py
@@ -177,8 +177,9 @@ class ChannelHeader(urwid.Pile):
             self.contents.pop()
             self.contents.append((divider, ('pack', 1)))
 
-    def __init__(self, name, topic, date=None, num_members=0, is_private=False,
-        pin_count=0, is_starred=False, is_dm_workaround_please_remove_me=False):
+    def __init__(self, name, topic, date=None, num_members=0, more_members=False, 
+        is_private=False, pin_count=0, is_starred=False, 
+        is_dm_workaround_please_remove_me=False):
         if is_starred:
             star_icon = ('starred', get_icon('full_star'))
         else:
@@ -198,7 +199,8 @@ class ChannelHeader(urwid.Pile):
         body = urwid.Columns([
             ('pack', BreadCrumbs([
                 star_icon,
-                '{} {}'.format(get_icon('person'), num_members),
+                '{} {}{}'.format(get_icon('person'), num_members, 
+                    "+" if more_members else ""),
                 '{} {}'.format(get_icon('pin'), pin_count)
             ])),
             urwid.AttrMap(self.topic_widget, None, 'edit_topic_focus')

--- a/sclack/store.py
+++ b/sclack/store.py
@@ -117,7 +117,7 @@ class Store:
         if channel_id[0] == 'G':
             return self.slack.api_call('groups.info', channel=channel_id)['group']
         elif channel_id[0] == 'C':
-            return self.slack.api_call('channels.info', channel=channel_id)['channel']
+            return self.slack.api_call('conversations.info', channel=channel_id)['channel']
         elif channel_id[0] == 'D':
             return self.slack.api_call('im.info', channel=channel_id)['im']
 

--- a/sclack/store.py
+++ b/sclack/store.py
@@ -121,6 +121,9 @@ class Store:
         elif channel_id[0] == 'D':
             return self.slack.api_call('im.info', channel=channel_id)['im']
 
+    def get_channel_members(self, channel_id):
+        return self.slack.api_call('conversations.members', channel=channel_id)
+
     def mark_read(self, channel_id, ts):
         if self.is_group(channel_id):
             return self.slack.api_call('groups.mark', channel=channel_id, ts=ts)
@@ -139,6 +142,7 @@ class Store:
     def load_channel(self, channel_id):
         if channel_id[0] in ('C', 'G', 'D'):
             self.state.channel = self.get_channel_info(channel_id)
+            self.state.members = self.get_channel_members(channel_id)
             self.state.did_render_new_messages = self.state.channel.get('unread_count_display', 0) == 0
 
     def load_channels(self):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,61 @@
+from sclack.quick_switcher import remove_diacritic
+from app import ask_for_token
+
+from slackclient import SlackClient
+
+def get_config():
+    json_config = {}
+    ask_for_token(json_config)
+    return json_config
+
+def get_token():
+    json_config = get_config()
+    return json_config['workspaces']['default']
+
+def get_slack_client():
+    return SlackClient(get_token())
+
+def test_workspace_token(): 
+    json_config = get_config()
+    assert json_config.get('workspaces', None) != None
+
+def test_auth():
+    client = get_slack_client()
+    auth = client.api_call('auth.test')
+    assert (auth != None) and (auth.get('ok', False) == True)
+
+
+def test_get_channels():
+    client = get_slack_client()
+    channels = client.api_call('users.conversations',
+            exclude_archived=True,
+            limit=10,  # 1k is max limit
+            types='public_channel,private_channel,im')
+    assert channels != None and channels.get('error', None) == None
+
+def test_get_members():
+    client = get_slack_client()
+    channels = client.api_call('users.conversations',
+            exclude_archived=True,
+            limit=10,  # 1k is max limit
+            types='public_channel,private_channel,im')
+    members = client.api_call('conversations.members', channel=channels['channels'][0]['id'])
+    assert members != None and members.get('error', None) == None
+
+def test_get_members_pagination1():
+    client = get_slack_client()
+    channels = client.api_call('users.conversations',
+            exclude_archived=True,
+            limit=10,  # 1k is max limit
+            types='public_channel,private_channel,im')
+    members = client.api_call('conversations.members', channel=channels['channels'][0]['id'], limit=1000)
+    assert members != None and members.get('response_metadata', None) != None
+
+def test_get_members_pagination2():
+    client = get_slack_client()
+    channels = client.api_call('users.conversations',
+            exclude_archived=True,
+            limit=10,  # 1k is max limit
+            types='public_channel,private_channel,im')
+    members = client.api_call('conversations.members', channel=channels['channels'][0]['id'], limit=1)
+    assert members != None and members.get('response_metadata', None) != None


### PR DESCRIPTION
Got errors on response from 'channel.info'. It's now 'conversations.info'. source: https://api.slack.com/methods/conversations.info

Got errors on accessing `state.channel.members`. Fixed by making a call to 'conversations.members' and caching result to `state.members`. source: https://api.slack.com/methods/conversations.members

Member lists can now possibly be paginated. Added a conditional '+' to the num_members display based on whether member list is paginated or not. source: https://api.slack.com/methods/conversations.members