### PR TITLE
Add basic thread support

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,11 +144,12 @@ Focus on message and press <kbd>r</kbd> (or your custom shortcut) to get permali
     "go_to_sidebar": "esc",
     "open_quick_switcher": "ctrl k",
     "quit_application": "q",
-    "set_edit_topic_mode": "t",
+    "set_edit_topic_mode": "ctrl t",
     "set_insert_mode": "i",
     "yank_message": "y",
     "get_permalink": "r",
-    "set_snooze": "ctrl d"
+    "set_snooze": "ctrl d",
+    "toggle_thread": "t"
   }
 }
 ```

--- a/app.py
+++ b/app.py
@@ -95,7 +95,6 @@ class App:
     def sidebar_column(self):
         return self.columns.contents[0]
 
-
     def start(self):
         self._loading = True
         loop.create_task(self.animate_loading())
@@ -467,6 +466,8 @@ class App:
             for reaction in message.get('reactions', [])
         ]
 
+        responses = ['1' for response in message.get('replies', [])]
+
         attachments = []
         for attachment in message.get('attachments', []):
             attachment_widget = Attachment(
@@ -506,7 +507,8 @@ class App:
             text,
             indicators,
             attachments=attachments,
-            reactions=reactions
+            reactions=reactions,
+            responses=responses
         )
 
         self.lazy_load_images(files, message)

--- a/app.py
+++ b/app.py
@@ -707,6 +707,7 @@ class App:
         else:
             # Show the chosen thread
             self.showing_thread = True
+            self.store.state.thread_parent = parent_ts
             loop.create_task(self._show_thread(channel_id, parent_ts))
 
     def handle_set_snooze_time(self, snoozed_time):
@@ -894,6 +895,11 @@ class App:
                 self.store.state.editing_widget.original_text = edit_result['text']
                 self.store.state.editing_widget.set_text(MarkdownText(edit_result['text']))
             self.leave_edit_mode()
+        if self.showing_thread:
+            channel = self.store.state.channel['id']
+            if message.strip() != '':
+                self.store.post_thread_message(channel, self.store.state.thread_parent, message)
+                self.leave_edit_mode()
         else:
             channel = self.store.state.channel['id']
             if message.strip() != '':

--- a/app.py
+++ b/app.py
@@ -466,7 +466,7 @@ class App:
             for reaction in message.get('reactions', [])
         ]
 
-        responses = ['1' for response in message.get('replies', [])]
+        responses = message.get('replies', [])
 
         attachments = []
         for attachment in message.get('attachments', []):

--- a/config.json
+++ b/config.json
@@ -13,12 +13,13 @@
         "go_to_sidebar": "esc",
         "open_quick_switcher": "ctrl k",
         "quit_application": "q",
-        "set_edit_topic_mode": "t",
+        "set_edit_topic_mode": "ctrl t",
         "set_insert_mode": "i",
         "toggle_sidebar": "s",
         "yank_message": "y",
         "get_permalink": "r",
-        "set_snooze": "ctrl d"
+        "set_snooze": "ctrl d",
+        "toggle_thread": "t"
     },
     "sidebar": {
         "width": 25,

--- a/sclack/component/message.py
+++ b/sclack/component/message.py
@@ -4,6 +4,7 @@ import urwid
 import pyperclip
 import webbrowser
 from sclack.store import Store
+from sclack.components import ThreadText
 from sclack.component.time import Time
 
 
@@ -20,7 +21,7 @@ class Message(urwid.AttrMap):
         'mark_read',
     ]
 
-    def __init__(self, ts, channel_id, user, text, indicators, reactions=(), attachments=()):
+    def __init__(self, ts, channel_id, user, text, indicators, reactions=(), attachments=(), responses=()):
         self.ts = ts
         self.channel_id = channel_id
         self.user_id = user.id
@@ -30,10 +31,15 @@ class Message(urwid.AttrMap):
         main_column = [urwid.Columns([('pack', user), self.text_widget])]
         main_column.extend(attachments)
         self._file_index = len(main_column)
+
         if reactions:
             main_column.append(urwid.Columns([
                 ('pack', reaction) for reaction in reactions
             ]))
+
+        if responses:
+            main_column.append(ThreadText(len(responses)))
+
         self.main_column = urwid.Pile(main_column)
         columns = [
             ('fixed', 7, Time(ts)),

--- a/sclack/component/message.py
+++ b/sclack/component/message.py
@@ -83,7 +83,7 @@ class Message(urwid.AttrMap):
         elif key == keymap['get_permalink']:
             # FIXME
             urwid.emit_signal(self, 'get_permalink', self, self.channel_id, self.ts)
-        elif key == keymap['toggle_thread']:
+        elif key == keymap['toggle_thread'] or key == keymap['cursor_right']:
             urwid.emit_signal(self, 'toggle_thread', self.channel_id, self.ts)
             return True
         elif key == 'enter':

--- a/sclack/component/message.py
+++ b/sclack/component/message.py
@@ -19,6 +19,7 @@ class Message(urwid.AttrMap):
         'quit_application',
         'set_insert_mode',
         'mark_read',
+        'toggle_thread',
     ]
 
     def __init__(self, ts, channel_id, user, text, indicators, reactions=(), attachments=(), responses=()):
@@ -82,6 +83,9 @@ class Message(urwid.AttrMap):
         elif key == keymap['get_permalink']:
             # FIXME
             urwid.emit_signal(self, 'get_permalink', self, self.channel_id, self.ts)
+        elif key == keymap['toggle_thread']:
+            urwid.emit_signal(self, 'toggle_thread', self.channel_id, self.ts)
+            return True
         elif key == 'enter':
             browser_name = Store.instance.config['features']['browser']
 

--- a/sclack/components.py
+++ b/sclack/components.py
@@ -894,6 +894,18 @@ class User(urwid.Text):
         super(User, self).__init__(markup)
 
 
+class ThreadText(urwid.Text):
+    """
+    A text element used to indicate the number of messages in a thread
+    """
+    def __init__(self, num_replies):
+        color = "#" + shorten_hex('146BF7')
+        markup = [
+            (urwid.AttrSpec(color, 'h235'), '[Thread ({})]'.format(num_replies))
+        ]
+        super(ThreadText, self).__init__(markup)
+
+
 class Workspace(urwid.AttrMap):
     __metaclass__ = urwid.MetaSignals
     signals = ['select_workspace']

--- a/sclack/components.py
+++ b/sclack/components.py
@@ -901,7 +901,7 @@ class ThreadText(urwid.Text):
     def __init__(self, num_replies):
         color = "#" + shorten_hex('146BF7')
         markup = [
-            (urwid.AttrSpec(color, 'h235'), '[Thread ({})]'.format(num_replies))
+            (urwid.AttrSpec(color, 'h235'), 'Thread ({})'.format(num_replies))
         ]
         super(ThreadText, self).__init__(markup)
 

--- a/sclack/store.py
+++ b/sclack/store.py
@@ -8,6 +8,7 @@ class State:
         self.groups = []
         self.stars = []
         self.messages = []
+        self.thread_messages = []
         self.users = []
         self.pin_count = 0
         self.has_more = False
@@ -80,6 +81,21 @@ class Store:
         self.state.is_limited = history.get('is_limited', False)
         self.state.pin_count = history['pin_count']
         self.state.messages.reverse()
+
+    def load_thread_messages(self, channel_id, parent_ts):
+        """
+        Load all of the messages sent in reply to the message with the given timestamp.
+        """
+        original = self.slack.api_call(
+            "conversations.history",
+            channel=channel_id,
+            latest=parent_ts,
+            inclusive=True,
+            limit=1
+        )
+
+        if len(original['messages']) > 0:
+            self.state.thread_messages = original['messages']
 
     def is_valid_channel_id(self, channel_id):
         """

--- a/sclack/store.py
+++ b/sclack/store.py
@@ -86,16 +86,14 @@ class Store:
         """
         Load all of the messages sent in reply to the message with the given timestamp.
         """
-        original = self.slack.api_call(
-            "conversations.history",
+        replies = self.slack.api_call(
+            "conversations.replies",
             channel=channel_id,
-            latest=parent_ts,
-            inclusive=True,
-            limit=1
+            ts=parent_ts,
         )
 
-        if len(original['messages']) > 0:
-            self.state.thread_messages = original['messages']
+        self.state.thread_messages = replies['messages']
+        self.state.has_more = replies.get('has_more', False)
 
     def is_valid_channel_id(self, channel_id):
         """

--- a/sclack/store.py
+++ b/sclack/store.py
@@ -9,6 +9,7 @@ class State:
         self.stars = []
         self.messages = []
         self.thread_messages = []
+        self.thread_parent = None
         self.users = []
         self.pin_count = 0
         self.has_more = False
@@ -231,6 +232,16 @@ class Store:
             as_user=True,
             link_names=True,
             text=message
+        )
+
+    def post_thread_message(self, channel_id, parent_ts, message):
+        return self.slack.api_call(
+            'chat.postMessage',
+            channel=channel_id,
+            as_user=True,
+            link_name=True,
+            text=message,
+            thread_ts=parent_ts
         )
 
     def get_presence(self, user_id):


### PR DESCRIPTION
This change adds some very basic thread support to the application:
- If a message in a channel has replies, show the number of messages in the thread
- Pressing 't' on a particular message shows a thread view with just the messages in the thread
- Pressing 't' on a message in a thread returns to the channel
- Posting a message while viewing a thread will post the message in the thread rather than in the channel

Resolves Issue #125 .