### PR TITLE
Display a channel's unread message count in sidebar.

### DIFF
--- a/sclack/components.py
+++ b/sclack/components.py
@@ -670,6 +670,14 @@ class Reaction(urwid.Text):
         super(Reaction, self).__init__(('reaction', text))
 
 
+class ReplyCount(urwid.Text):
+    def __init__(self, count):
+        if count == 1:
+            text = '1 reply'
+        else:
+            text = '{count} replies'.format(count=count)
+        super(ReplyCount, self).__init__(('reply_count', text))
+
 class SideBar(urwid.Frame):
     __metaclass__ = urwid.MetaSignals
     signals = ['go_to_channel']

--- a/sclack/store.py
+++ b/sclack/store.py
@@ -117,7 +117,7 @@ class Store:
         if channel_id[0] == 'G':
             return self.slack.api_call('groups.info', channel=channel_id)['group']
         elif channel_id[0] == 'C':
-            return self.slack.api_call('conversations.info', channel=channel_id)['channel']
+            return self.slack.api_call('channels.info', channel=channel_id)['channel']
         elif channel_id[0] == 'D':
             return self.slack.api_call('im.info', channel=channel_id)['im']
 

--- a/tests/components/test_reply_count.py
+++ b/tests/components/test_reply_count.py
@@ -1,0 +1,11 @@
+from sclack.components import ReplyCount
+
+
+def test_display_text_for_single_reply():
+    reply_count = ReplyCount(1)
+    assert reply_count.text == '1 reply'
+
+
+def test_display_text_for_multiple_replies():
+    reply_count = ReplyCount(12)
+    assert reply_count.text == '12 replies'


### PR DESCRIPTION
The channel listing on the sidebar was not displaying whether channels had unread messages in them. The cause was that `conversations.info` (the API endpoint being called) does not include the count of unread messages any longer. The Slack API changelog documents that this data was removed from that endpoint in October 2017 (see the `October 2017` section of https://api.slack.com/changelog).

Calling the `channels.info` endpoint instead will provide the unread messages count (and all the other necessary data, from what I can see looking at the API documentation).

Thanks for your work on this project! I am always looking for more ways to stay in the terminal.