### PR TITLE
Bugfix: Unread message count for channels.

### DIFF
--- a/sclack/store.py
+++ b/sclack/store.py
@@ -117,7 +117,7 @@ class Store:
         if channel_id[0] == 'G':
             return self.slack.api_call('groups.info', channel=channel_id)['group']
         elif channel_id[0] == 'C':
-            return self.slack.api_call('conversations.info', channel=channel_id)['channel']
+            return self.slack.api_call('channels.info', channel=channel_id)['channel']
         elif channel_id[0] == 'D':
             return self.slack.api_call('im.info', channel=channel_id)['im']
 


### PR DESCRIPTION
Channels are not displaying their unread message count. This is due to a breaking change to the Slack API response to `conversations.info`, which no longer contains `unread_count_display`. This data is now available from the `channels.info` endpoint.

The API change is documented in the October 2017 section of https://api.slack.com/changelog.