### PR TITLE
Replace deprecated api actions affecting groups store

### DIFF
--- a/sclack/store.py
+++ b/sclack/store.py
@@ -114,9 +114,7 @@ class Store:
         return channel_id[0] == 'G'
 
     def get_channel_info(self, channel_id):
-        if channel_id[0] == 'G':
-            return self.slack.api_call('groups.info', channel=channel_id)['group']
-        elif channel_id[0] == 'C':
+        if channel_id[0] in ('C', 'G'):
             return self.slack.api_call('conversations.info', channel=channel_id)['channel']
         elif channel_id[0] == 'D':
             return self.slack.api_call('im.info', channel=channel_id)['im']
@@ -167,7 +165,7 @@ class Store:
         self.state.dms.sort(key=lambda dm: dm['created'])
 
     def load_groups(self):
-        self.state.groups = self.slack.api_call('mpim.list')['groups']
+        self.state.groups = filter(lambda c: c['is_group'] is True, self.slack.api_call('conversations.list'))
 
     def load_stars(self):
         """


### PR DESCRIPTION
Replaces deprecated api actions `mpim.list` and `groups.info`, which are affecting populating and using the data in the groups store when the Slack token was generated after July 10th. See #135.

I ran the test suite and it passed and I've tested manually with the change in this PR briefly and it seems to resolve the issue (though I just started using this app, so I'm not all that familiar with it yet). Let me know if you need anything else from me.