### PR TITLE
Add python 3.5 as minimal required version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-asyncio
 urwid==2.0.1
 pyperclip==1.6.2
 requests

--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,8 @@ setup(
     url='https://github.com/haskellcamargo/sclack',
     scripts=["app.py"],
     packages=find_packages(),
+    python_requires=">=3.5",
     install_requires=[
-        'asyncio',
         'urwid>2',
         'pyperclip',
         'requests',


### PR DESCRIPTION
Python 3.4 added the asyncio module into the standard library, but
starting with 3.5 we can make use of the "async def" style syntax.
Python 3.8 deprecated the current decorator style declarations.

After this it should be safe to merge #129.